### PR TITLE
Fix ArgumentMultimap, ArgumentTokenizer to parse Add command

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
@@ -23,9 +24,10 @@ import seedu.address.model.person.Course;
  */
 public class AddCommandParser implements Parser<AddCommand> {
 
-    // public AddCommand parse(String args) throws ParseException {
-    //     return new AddCommand(new Person(new Id("A1234567B"), new Name("Walter White")));
-    // }
+    // Placeholder values for optional fields
+    private static String PHONE_PLACEHOLDER = "00000000";
+    private static String EMAIL_PLACEHOLDER = "placeholder@u.nus.edu";
+    private static String COURSE_PLACEHOLDER = "Add course";
 
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand
@@ -41,12 +43,13 @@ public class AddCommandParser implements Parser<AddCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ID, PREFIX_COURSE);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_ID);
+
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Id id = ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get());
-        Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
-        Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
-        Course course = ParserUtil.parseCourse(argMultimap.getValue(PREFIX_COURSE).get());
+        Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).orElse(PHONE_PLACEHOLDER));
+        Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).orElse(EMAIL_PLACEHOLDER));
+        Course course = ParserUtil.parseCourse(argMultimap.getValue(PREFIX_COURSE).orElse(COURSE_PLACEHOLDER));
 
         Person person = new Person(id, name, phone, email, course);
 
@@ -58,7 +61,14 @@ public class AddCommandParser implements Parser<AddCommand> {
      * {@code ArgumentMultimap}.
      */
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+        return Stream.of(prefixes).allMatch(prefix -> {
+            Optional<String> value = argumentMultimap.getValue(prefix);
+            boolean isPresent = value.isPresent() && !value.get().trim().isEmpty();  // Also check if the value is not empty
+            if (!isPresent) {
+                System.out.println("Missing or empty value for prefix: " + prefix.getPrefix());
+            }
+            return isPresent;
+        });
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -51,18 +51,15 @@ public class ArgumentTokenizer {
     }
 
     /**
-     * {@see findAllPrefixPositions}
+     * Finds all occurrences of a given prefix in the arguments string.
      */
     private static List<PrefixPosition> findPrefixPositions(String argsString, Prefix prefix) {
         List<PrefixPosition> positions = new ArrayList<>();
-
         int prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), 0);
         while (prefixPosition != -1) {
-            PrefixPosition extendedPrefix = new PrefixPosition(prefix, prefixPosition);
-            positions.add(extendedPrefix);
-            prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), prefixPosition);
+            positions.add(new PrefixPosition(prefix, prefixPosition));
+            prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), prefixPosition + 1);
         }
-
         return positions;
     }
 
@@ -77,8 +74,8 @@ public class ArgumentTokenizer {
      *         not found
      */
     private static int findPrefixPosition(String argsString, String prefix, int fromIndex) {
-        int prefixIndex = argsString.indexOf(" /" + prefix, fromIndex); // Ensure space before /
-        return prefixIndex == -1 ? -1 : prefixIndex + 1; // Adjust to start at '/'
+        int prefixIndex = argsString.indexOf(prefix, fromIndex); // Simplified search
+        return prefixIndex == -1 ? -1 : prefixIndex; // Return position directly
     }
 
     /**
@@ -95,22 +92,18 @@ public class ArgumentTokenizer {
      * @return ArgumentMultimap object that maps prefixes to their arguments
      */
     private static ArgumentMultimap extractArguments(String argsString, List<PrefixPosition> prefixPositions) {
-
         // Sort by start position
         prefixPositions.sort((prefix1, prefix2) -> prefix1.getStartPosition() - prefix2.getStartPosition());
 
         // Insert a PrefixPosition to represent the preamble
-        PrefixPosition preambleMarker = new PrefixPosition(new Prefix(""), 0);
-        prefixPositions.add(0, preambleMarker);
+        prefixPositions.add(0, new PrefixPosition(new Prefix(""), 0));
 
         // Add a dummy PrefixPosition to represent the end of the string
-        PrefixPosition endPositionMarker = new PrefixPosition(new Prefix(""), argsString.length());
-        prefixPositions.add(endPositionMarker);
+        prefixPositions.add(new PrefixPosition(new Prefix(""), argsString.length()));
 
         // Map prefixes to their argument values (if any)
         ArgumentMultimap argMultimap = new ArgumentMultimap();
         for (int i = 0; i < prefixPositions.size() - 1; i++) {
-            // Extract and store prefixes and their arguments
             Prefix argPrefix = prefixPositions.get(i).getPrefix();
             String argValue = extractArgumentValue(argsString, prefixPositions.get(i), prefixPositions.get(i + 1));
             argMultimap.put(argPrefix, argValue);
@@ -129,8 +122,7 @@ public class ArgumentTokenizer {
             PrefixPosition nextPrefixPosition) {
         Prefix prefix = currentPrefixPosition.getPrefix();
         int valueStartPos = currentPrefixPosition.getStartPosition() + prefix.getPrefix().length() + 1; // +1 for space
-        String value = argsString.substring(valueStartPos, nextPrefixPosition.getStartPosition());
-        return value.trim();
+        return argsString.substring(valueStartPos, nextPrefixPosition.getStartPosition()).trim();
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Course.java
+++ b/src/main/java/seedu/address/model/person/Course.java
@@ -9,20 +9,19 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Course {
 
-    public static final String MESSAGE_CONSTRAINTS =
-            "Course names should only contain alphanumeric characters and spaces, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Course names should only contain alphanumeric characters and spaces, and it should not be blank";
 
-    /**
-     * The first character of the course must not be a whitespace,
+    /*
+     * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[^\\s].*";
 
     public final String course;
 
     /**
      * Constructs a {@code Course}.
-     * 
+     *
      * @param course A valid course.
      */
     public Course(String course) {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -25,17 +25,6 @@ public class Person {
     private final List<Note> notes;
 
     /**
-     * Overloaded Constructor for Person.
-     * Used when initializing a new Person object with minimal details.
-     *
-     * @param id   The id of the person.
-     * @param name The name of the person.
-     */
-    public Person(Id id, Name name) {
-        this(id, name, new Phone(""), new Email(""), new Course(""));
-    }
-
-    /**
      * Constructor for Person.
      * Used when initializing a new Person object with full details.
      *
@@ -61,7 +50,7 @@ public class Person {
     /**
      * Constructor for Person.
      * Used when setting all fields of a Person object.
-     * 
+     *
      * @param id            The student ID of the person.
      * @param name          The name of the person.
      * @param phone         The phone number of the person.


### PR DESCRIPTION
Fix `ArgumentMultimap`, `ArgumentTokenizer` to parse Add command

- Fix parser to accept our new syntax of `command /option arg1`
- Fix Add command  
- Delete unused overload constructor in `Person` 
- Replace regex command in `Course` to accept any string that does not begin with a whitespace