### PR TITLE
Change output message of Edit Command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -1,10 +1,13 @@
 package seedu.address.logic;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javafx.util.Pair;
 import seedu.address.logic.parser.Prefix;
+import seedu.address.model.person.Id;
 import seedu.address.model.person.Person;
 
 /**
@@ -58,4 +61,20 @@ public class Messages {
         return builder.toString();
     }
 
+    /**
+     * Formats the {@code updatedFields} to be displayed as output for Edit command.
+     * 
+     * @param oldId original ID to identify person edited.
+     */
+    public static String editFormat(Id oldId, List<Pair<String, String>> updatedFields) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Original Id: " + oldId + ", ");
+
+        for (Pair<String, String> p : updatedFields) {
+            sb.append(p.getKey() + ": " + p.getValue() + ", ");
+        }
+        sb.delete(sb.length() - 2, sb.length()); // remove last comma
+
+        return sb.toString();
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -33,8 +33,8 @@ public class AddCommand extends Command {
             %s COURSE
 
             Example:
-            add /name Walter White /id A1234567B
-            add /name Jesse Pinkman /id A1234567C /phone 98765432 /email jesse@nus.edu.sg /course CS2103T
+            add /name Walter White /id A1234567N
+            add /name Jesse Pinkman /id HT1234567U /phone 98765432 /email jesse@nus.edu.sg /course CS2103T
             """;
 
     public static final String MESSAGE_USAGE = String.format(MESSAGE_USAGE_UNFORMATTED, COMMAND_WORD,

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -9,9 +9,12 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import javafx.util.Pair;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -89,7 +92,11 @@ public class EditCommand extends Command {
 
             model.setPerson(personToEdit, editedPerson);
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-            return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
+
+            List<Pair<String, String>> updatedFields = getUpdatedFields(personToEdit, editedPerson);
+
+            return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS,
+                    Messages.editFormat(personToEdit.getId(), updatedFields)));
         } catch (PersonNotFoundException e) {
             throw new CommandException(e.getMessage());
         }
@@ -111,6 +118,36 @@ public class EditCommand extends Command {
         return new Person(updatedId, updatedName, updatedPhone, updatedEmail, updatedCourse, 
                 personToEdit.getAttendance(), personToEdit.getParticipation(), personToEdit.getGrade(),
                 personToEdit.getNotes());
+    }
+
+    /**
+     * Returns the list of changed fields between {@code personToEdit} and
+     * {@code editedPerson} and their values.
+     */
+    private List<Pair<String, String>> getUpdatedFields(Person personToEdit, Person editedPerson) {
+        List<Pair<String, String>> updatedFields = new ArrayList<>();
+
+        if (!personToEdit.getId().equals(editedPerson.getId())) {
+            updatedFields.add(new Pair<>("New Id", editedPerson.getId().toString()));
+        }
+
+        if (!personToEdit.getName().equals(editedPerson.getName())) {
+            updatedFields.add(new Pair<>("Name", editedPerson.getName().toString()));
+        }
+
+        if (!personToEdit.getPhone().equals(editedPerson.getPhone())) {
+            updatedFields.add(new Pair<>("Phone", editedPerson.getPhone().toString()));
+        }
+
+        if (!personToEdit.getEmail().equals(editedPerson.getEmail())) {
+            updatedFields.add(new Pair<>("Email", editedPerson.getEmail().toString()));
+        }
+
+        if (!personToEdit.getCourse().equals(editedPerson.getCourse())) {
+            updatedFields.add(new Pair<>("Course", editedPerson.getCourse().toString()));
+        }
+
+        return updatedFields;
     }
 
     @Override

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -11,7 +11,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_GRADE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB; 
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NOTE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NOTE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PARTICIPATION_AMY;


### PR DESCRIPTION
Fixes #71 

The output message contains details for properties that were not changed.

Aside from Id, other properties that were not changed are redundant. These would only clutter up the output message.

Let's update the output of the Edit command to only show the (original) Id of the person edited and the respective properties that have been changed.

This way, the output message becomes more concise and relevant. The Id is included to identify the person that has been edited.