### PR TITLE
Update ArgumentTokenizerTest

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -32,8 +32,12 @@ public class ArgumentTokenizer {
      * @return ArgumentMultimap object that maps prefixes to their arguments
      */
     public static ArgumentMultimap tokenize(String argsString, Prefix... prefixes) {
-        List<PrefixPosition> positions = findAllPrefixPositions(argsString, prefixes);
-        return extractArguments(argsString, positions);
+        try {
+            List<PrefixPosition> positions = findAllPrefixPositions(argsString, prefixes);
+            return extractArguments(argsString, positions);
+        } catch (IndexOutOfBoundsException e) {
+            return new ArgumentMultimap();
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.parser;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
@@ -53,10 +52,10 @@ public class AddCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
 
         // missing name prefix
-        assertParseFailure(parser, "add /id A0123456N", expectedMessage);
+        assertParseFailure(parser, " /id A0123456N", expectedMessage);
 
         // missing id prefix
-        assertParseFailure(parser, "add /name Alice", expectedMessage);
+        assertParseFailure(parser, " /name Alice", expectedMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -7,20 +7,26 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ * Contains tests for {@code ArgumentTokenizer}.
+ */
 public class ArgumentTokenizerTest {
 
-    private final Prefix unknownPrefix = new Prefix("--u");
-    private final Prefix pSlash = new Prefix("p/");
-    private final Prefix dashT = new Prefix("-t");
-    private final Prefix hatQ = new Prefix("^Q");
+    // Prefixes used in the tests below.
+    private static final Prefix slashOption = new Prefix("/option");
+    private static final Prefix slashBar = new Prefix("/bar");
+    private static final Prefix slashFoo = new Prefix("/foo");
 
+    /**
+     * Prefixes used in the tests below.
+     */
     @Test
     public void tokenize_emptyArgsString_noValues() {
         String argsString = "  ";
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, slashOption);
 
         assertPreambleEmpty(argMultimap);
-        assertArgumentAbsent(argMultimap, pSlash);
+        assertArgumentAbsent(argMultimap, slashOption);
     }
 
     private void assertPreamblePresent(ArgumentMultimap argMultimap, String expectedPreamble) {
@@ -53,9 +59,12 @@ public class ArgumentTokenizerTest {
         assertFalse(argMultimap.getValue(prefix).isPresent());
     }
 
+    /**
+     * Asserts that all prefixes in {@code argMultimap} are absent.
+     */
     @Test
     public void tokenize_noPrefixes_allTakenAsPreamble() {
-        String argsString = "  some random string /t tag with leading and trailing spaces ";
+        String argsString = "  some random string /option tag with leading and trailing spaces ";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString);
 
         // Same string expected as preamble, but leading/trailing spaces should be trimmed
@@ -63,77 +72,60 @@ public class ArgumentTokenizerTest {
 
     }
 
+    /**
+     * Asserts that the preamble and arguments are correctly tokenized.
+     */
     @Test
     public void tokenize_oneArgument() {
         // Preamble present
-        String argsString = "  Some preamble string p/ Argument value ";
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash);
+        String argsString = "  Some preamble string /option Argument value ";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, slashOption);
         assertPreamblePresent(argMultimap, "Some preamble string");
-        assertArgumentPresent(argMultimap, pSlash, "Argument value");
+        assertArgumentPresent(argMultimap, slashOption, "Argument value");
 
         // No preamble
-        argsString = " p/   Argument value ";
-        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash);
+        argsString = " /option   Argument value ";
+        argMultimap = ArgumentTokenizer.tokenize(argsString, slashOption);
         assertPreambleEmpty(argMultimap);
-        assertArgumentPresent(argMultimap, pSlash, "Argument value");
+        assertArgumentPresent(argMultimap, slashOption, "Argument value");
 
     }
 
+    /**
+     * Asserts that the preamble and arguments are correctly tokenized.
+     */
     @Test
     public void tokenize_multipleArguments() {
         // Only two arguments are present
-        String argsString = "SomePreambleString -t dashT-Value p/pSlash value";
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
-        assertPreamblePresent(argMultimap, "SomePreambleString");
-        assertArgumentPresent(argMultimap, pSlash, "pSlash value");
-        assertArgumentPresent(argMultimap, dashT, "dashT-Value");
-        assertArgumentAbsent(argMultimap, hatQ);
+        String argsString = " somePreambleString /option value1 /bar value2";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, slashBar, slashOption);
+        assertPreamblePresent(argMultimap, "somePreambleString");
+        assertArgumentPresent(argMultimap, slashBar, "value2");
+        assertArgumentPresent(argMultimap, slashOption, "value1");
 
         // All three arguments are present
-        argsString = "Different Preamble String ^Q111 -t dashT-Value p/pSlash value";
-        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
-        assertPreamblePresent(argMultimap, "Different Preamble String");
-        assertArgumentPresent(argMultimap, pSlash, "pSlash value");
-        assertArgumentPresent(argMultimap, dashT, "dashT-Value");
-        assertArgumentPresent(argMultimap, hatQ, "111");
+        argsString = " preamble /option 1 /bar CQ /foo YouFool";
+        argMultimap = ArgumentTokenizer.tokenize(argsString, slashBar, slashFoo, slashOption);
+        assertPreamblePresent(argMultimap, "preamble");
+        assertArgumentPresent(argMultimap, slashBar, "CQ");
+        assertArgumentPresent(argMultimap, slashFoo, "YouFool");
+        assertArgumentPresent(argMultimap, slashOption, "1");
 
         /* Also covers: Reusing of the tokenizer multiple times */
 
         // Reuse tokenizer on an empty string to ensure ArgumentMultimap is correctly reset
         // (i.e. no stale values from the previous tokenizing remain)
         argsString = "";
-        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+        argMultimap = ArgumentTokenizer.tokenize(argsString, slashOption, slashFoo, slashBar);
         assertPreambleEmpty(argMultimap);
-        assertArgumentAbsent(argMultimap, pSlash);
+        assertArgumentAbsent(argMultimap, slashOption);
 
         /* Also covers: testing for prefixes not specified as a prefix */
 
         // Prefixes not previously given to the tokenizer should not return any values
-        argsString = unknownPrefix + "some value";
-        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
-        assertArgumentAbsent(argMultimap, unknownPrefix);
-        assertPreamblePresent(argMultimap, argsString); // Unknown prefix is taken as part of preamble
-    }
-
-    @Test
-    public void tokenize_multipleArgumentsWithRepeats() {
-        // Two arguments repeated, some have empty values
-        String argsString = "SomePreambleString -t dashT-Value ^Q ^Q -t another dashT value p/ pSlash value -t";
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
-        assertPreamblePresent(argMultimap, "SomePreambleString");
-        assertArgumentPresent(argMultimap, pSlash, "pSlash value");
-        assertArgumentPresent(argMultimap, dashT, "dashT-Value", "another dashT value", "");
-        assertArgumentPresent(argMultimap, hatQ, "", "");
-    }
-
-    @Test
-    public void tokenize_multipleArgumentsJoined() {
-        String argsString = "SomePreambleStringp/ pSlash joined-tjoined -t not joined^Qjoined";
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
-        assertPreamblePresent(argMultimap, "SomePreambleStringp/ pSlash joined-tjoined");
-        assertArgumentAbsent(argMultimap, pSlash);
-        assertArgumentPresent(argMultimap, dashT, "not joined^Qjoined");
-        assertArgumentAbsent(argMultimap, hatQ);
+        argsString = " /unknown /lol /kek";
+        argMultimap = ArgumentTokenizer.tokenize(argsString, slashOption, slashFoo, slashBar);
+        assertArgumentAbsent(argMultimap, slashOption);
     }
 
     @Test


### PR DESCRIPTION
Resolves #61 
- Update unit tests for `ArgumentTokenizerTest` 
- Update `ArgumentTokenizer` to handle `IndexOutOfBoundException` by returning an empty `ArgumentMultimap`