### PR TITLE
Fix bug in LogicManagerTest

### DIFF
--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -61,7 +61,7 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete A0000000A";
+        String deleteCommand = "delete /id A0000000A";
         assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_ID);
     }
 


### PR DESCRIPTION
A test case in LogicManagerTest now fails since we changed the command format of the Delete command.

We should update the test case to reflect this change in format.

Let's update the test case to reflect this change.

This way, all test cases follow our intended command formats.