### PR TITLE
Add Student Grades to Address Books

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -114,9 +114,10 @@ public class EditCommand extends Command {
         Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Course updatedCourse = editPersonDescriptor.getCourse().orElse(personToEdit.getCourse());
+        Grade updatedGrade = editPersonDescriptor.getGrade().orElse(personToEdit.getGrade());
 
         return new Person(updatedId, updatedName, updatedPhone, updatedEmail, updatedCourse,
-                personToEdit.getAttendance(), personToEdit.getParticipation(), personToEdit.getGrade(),
+                personToEdit.getAttendance(), personToEdit.getParticipation(), updatedGrade,
                 personToEdit.getNotes());
     }
 
@@ -145,6 +146,10 @@ public class EditCommand extends Command {
 
         if (!personToEdit.getCourse().equals(editedPerson.getCourse())) {
             updatedFields.add(new Pair<>("Course", editedPerson.getCourse().toString()));
+        }
+
+        if (!personToEdit.getGrade().equals(editedPerson.getGrade())) {
+            updatedFields.add(new Pair<>("Grade", editedPerson.getGrade().toString()));
         }
 
         return updatedFields;
@@ -197,7 +202,6 @@ public class EditCommand extends Command {
         public EditPersonDescriptor() {
             setAttendance(new Attendance());
             setParticipation(new Participation());
-            setGrade(new Grade());
             setNote(new Note("NA"));
         }
 
@@ -220,7 +224,7 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(newId, name, phone, email, course);
+            return CollectionUtil.isAnyNonNull(newId, name, phone, email, course, grade);
         }
 
         public void setNewId(Id newId) {

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,23 +1,15 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.*;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.Course;
-import seedu.address.model.person.Email;
-import seedu.address.model.person.Id;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
+import seedu.address.model.person.*;
 
 /**
  * Parses input arguments and creates a new AddCommand object
@@ -37,7 +29,7 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                PREFIX_ID, PREFIX_COURSE);
+                PREFIX_ID, PREFIX_COURSE, PREFIX_GRADE);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ID)
                 || !argMultimap.getPreamble().isEmpty()) {
@@ -52,8 +44,12 @@ public class AddCommandParser implements Parser<AddCommand> {
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL)
                 .orElse(String.format(EMAIL_PLACEHOLDER, name.toString().toLowerCase().strip().replace(" ", ""))));
         Course course = ParserUtil.parseCourse(argMultimap.getValue(PREFIX_COURSE).orElse(COURSE_PLACEHOLDER));
+        Optional<String> gradeString = argMultimap.getValue(PREFIX_GRADE);
+        Grade grade = gradeString.map(s -> new Grade(Integer.parseInt(s))).orElse(new Grade());
 
-        Person person = new Person(id, name, phone, email, course);
+
+        Person person = new Person(id, name, phone, email, course, new Attendance(), new Participation(), grade, List.of());
+
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,15 +1,23 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.*;
+import seedu.address.model.person.Course;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Id;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
 
 /**
  * Parses input arguments and creates a new AddCommand object
@@ -29,7 +37,7 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                PREFIX_ID, PREFIX_COURSE, PREFIX_GRADE);
+                PREFIX_ID, PREFIX_COURSE);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ID)
                 || !argMultimap.getPreamble().isEmpty()) {
@@ -44,12 +52,8 @@ public class AddCommandParser implements Parser<AddCommand> {
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL)
                 .orElse(String.format(EMAIL_PLACEHOLDER, name.toString().toLowerCase().strip().replace(" ", ""))));
         Course course = ParserUtil.parseCourse(argMultimap.getValue(PREFIX_COURSE).orElse(COURSE_PLACEHOLDER));
-        Optional<String> gradeString = argMultimap.getValue(PREFIX_GRADE);
-        Grade grade = gradeString.map(s -> new Grade(Integer.parseInt(s))).orElse(new Grade());
 
-
-        Person person = new Person(id, name, phone, email, course, new Attendance(), new Participation(), grade, List.of());
-
+        Person person = new Person(id, name, phone, email, course);
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -2,12 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_ID;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.*;
 
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
@@ -28,10 +23,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_ID, PREFIX_NEW_ID, PREFIX_NAME, PREFIX_PHONE,
-                        PREFIX_EMAIL, PREFIX_COURSE);
+                        PREFIX_EMAIL, PREFIX_COURSE, PREFIX_GRADE);
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_ID, PREFIX_NEW_ID, PREFIX_NAME, PREFIX_PHONE,
-                PREFIX_EMAIL, PREFIX_COURSE);
+                PREFIX_EMAIL, PREFIX_COURSE, PREFIX_GRADE);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
@@ -55,6 +50,11 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_COURSE).isPresent()) {
             editPersonDescriptor.setCourse(ParserUtil.parseCourse(argMultimap.getValue(PREFIX_COURSE).get()));
         }
+        if (argMultimap.getValue(PREFIX_GRADE).isPresent()) {
+            int gradeValue = Integer.parseInt(argMultimap.getValue(PREFIX_GRADE).get());
+            editPersonDescriptor.setGrade(new seedu.address.model.person.Grade(gradeValue));
+        }
+
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -37,6 +37,8 @@ public class PersonCard extends UiPart<Region> {
     private Label email;
     @FXML
     private Label course;
+    @FXML
+    private Label grade;
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
@@ -50,5 +52,11 @@ public class PersonCard extends UiPart<Region> {
         phone.setText(person.getPhone().value);
         email.setText(person.getEmail().value);
         course.setText(person.getCourse().course);
+        int gradeValue = person.getGrade().grade;
+        if (gradeValue == -1) {
+            grade.setText("Grade: N/A");
+        } else {
+            grade.setText("Grade: " + gradeValue);
+        }
     }
 }

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -31,6 +31,7 @@
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
       <Label fx:id="course" styleClass="cell_small_label" text="\$course" />
+      <Label fx:id="grade" styleClass="cell_small_label" text="Grade" />
     </VBox>
   </GridPane>
 </HBox>


### PR DESCRIPTION
Fixes #129 

Adds the ability to set (edit) grades for students in the address book. Grades are also displayed (as N/A) when a person is added.