### PR TITLE
Change course placeholder to match the new regex

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -27,7 +27,7 @@ public class AddCommandParser implements Parser<AddCommand> {
     // Placeholder values for optional fields
     private static final String PHONE_PLACEHOLDER = "00000000";
     private static final String EMAIL_PLACEHOLDER = "%s@u.nus.edu";
-    private static final String COURSE_PLACEHOLDER = "No course specified";
+    private static final String COURSE_PLACEHOLDER = "AAA0000AA";
 
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand


### PR DESCRIPTION
The old placeholder "No course specified" does not match our new validation. I have changed it to "AAA0000AA".

The tests will still fail as I have not updated yet.