### PR TITLE
Add test classes for sort functionality and modify existing classes

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -2,9 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import seedu.address.logic.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.person.Person;
 
 import java.util.Comparator;
 
@@ -26,4 +24,15 @@ public class SortCommand extends Command {
         model.sortFilteredPersonList(Comparator.comparing(person -> person.getName().toString()));
         return new CommandResult(MESSAGE_SUCCESS);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this || other instanceof SortCommand;
+    }
+
+    @Override
+    public int hashCode() {
+        return SortCommand.class.hashCode();
+    }
+
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -10,6 +10,7 @@ import static seedu.address.testutil.TypicalPersons.ALICE;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -157,6 +158,11 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void sortFilteredPersonList(Comparator<Person> comparator) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+public class SortCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_sortByName_success() {
+        expectedModel.sortFilteredPersonList(Comparator.comparing(p -> p.getName().toString()));
+        SortCommand sortCommand = new SortCommand();
+
+        assertCommandSuccess(sortCommand, model, SortCommand.MESSAGE_SUCCESS, expectedModel);
+
+        List<String> sortedNames = model.getFilteredPersonList().stream()
+                .map(p -> p.getName().toString())
+                .collect(Collectors.toList());
+
+        List<String> expectedNames = expectedModel.getFilteredPersonList().stream()
+                .map(p -> p.getName().toString())
+                .collect(Collectors.toList());
+
+        assertEquals(expectedNames, sortedNames);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -1,0 +1,23 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.SortCommand;
+
+public class SortCommandParserTest {
+
+    private SortCommandParser parser = new SortCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsSortCommand() {
+        assertParseSuccess(parser, "", new SortCommand());
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, " extraArg", SortCommand.MESSAGE_USAGE);
+    }
+}


### PR DESCRIPTION
Fixes #141 

New sort functionality required new test classes to be made. 

AddCommandTest was also updated (the test must NOT test the functionality of sort, as intended). 