### PR TITLE
Modify the resetRecords method and the affected test

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -124,7 +124,7 @@ public class AddressBook implements ReadOnlyAddressBook {
                 person.getCourse(),
                 new Attendance(),
                 new Participation(),
-                new Grade(),
+                person.getGrade(),
                 person.getNotes()
             );
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -8,7 +8,6 @@ import java.util.List;
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.person.Attendance;
-import seedu.address.model.person.Grade;
 import seedu.address.model.person.Id;
 import seedu.address.model.person.Participation;
 import seedu.address.model.person.Person;

--- a/src/test/java/seedu/address/logic/commands/ResetRecordsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ResetRecordsCommandTest.java
@@ -35,7 +35,7 @@ public class ResetRecordsCommandTest {
 
             PersonBuilder personInList = new PersonBuilder(originalPerson);
             Person resetPerson = personInList.withAttendance("UNMARKED").withParticipation("UNMARKED")
-                    .withGrade(-1).build();
+                    .build();
 
             expectedModel.setPerson(person, resetPerson);
         }


### PR DESCRIPTION
The original method clears attendance, participation, and grade. From our implementation, grade should not be cleared.