### PR TITLE
Edit 'Sort' Command Syntax to Match Other Commands Better

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -18,8 +18,9 @@ public class SortCommand extends Command {
     public static final String COMMAND_WORD = "sort";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts all persons by the specified field.\n"
-            + "Parameters: name | grade | attendance | participation\n"
-            + "Example: " + COMMAND_WORD + " grade";
+            + "Parameters: /by FIELD\n"
+            + "FIELD can be: name | grade | attendance | participation\n"
+            + "Example: sort /by grade";
 
     public static final String MESSAGE_SUCCESS = "Persons sorted by %s.";
 

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -20,4 +20,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_FILE_SAVE = new Prefix("/save");
     public static final Prefix PREFIX_FILE_APPEND = new Prefix("/append");
     public static final Prefix PREFIX_FILE_LIST = new Prefix("/list");
+    public static final Prefix PREFIX_BY = new Prefix("/by");
+
 }

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_BY;
+
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.commands.SortCommand.SortDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -11,20 +13,27 @@ public class SortCommandParser implements Parser<SortCommand> {
 
     @Override
     public SortCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim().toLowerCase();
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_BY);
 
-        if (trimmedArgs.isEmpty()) {
-            throw new ParseException("Missing sort field.\n" + SortCommand.MESSAGE_USAGE);
+        if (!argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException("Sort command must include the /by prefix.\n" + SortCommand.MESSAGE_USAGE);
         }
 
-        String[] tokens = trimmedArgs.split("\\s+");
+        if (!argMultimap.getValue(PREFIX_BY).isPresent()) {
+            throw new ParseException("Missing /by and sort field.\n" + SortCommand.MESSAGE_USAGE);
+        }
 
-        if (tokens.length > 1) {
+
+        String[] tokens = argMultimap.getValue(PREFIX_BY).get().trim().toLowerCase().split("\\s+");
+
+        if (tokens.length != 1) {
             throw new ParseException("Only one sort field is allowed.\n" + SortCommand.MESSAGE_USAGE);
         }
 
-        SortDescriptor descriptor = new SortDescriptor();
         String field = tokens[0];
+
+
+        SortDescriptor descriptor = new SortDescriptor();
 
         switch (field) {
         case "name":

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -6,34 +6,63 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.commands.SortCommand.SortDescriptor;
 
 public class SortCommandParserTest {
 
     private final SortCommandParser parser = new SortCommandParser();
 
     @Test
-    public void parse_validArgs_returnsSortCommand() {
-        SortCommand.SortDescriptor name = new SortCommand.SortDescriptor();
-        name.setSortByName();
-        assertParseSuccess(parser, "name", new SortCommand(name));
-
-        SortCommand.SortDescriptor grade = new SortCommand.SortDescriptor();
-        grade.setSortByGrade();
-        assertParseSuccess(parser, "grade", new SortCommand(grade));
-
-        SortCommand.SortDescriptor attendance = new SortCommand.SortDescriptor();
-        attendance.setSortByAttendance();
-        assertParseSuccess(parser, "attendance", new SortCommand(attendance));
-
-        SortCommand.SortDescriptor participation = new SortCommand.SortDescriptor();
-        participation.setSortByParticipation();
-        assertParseSuccess(parser, "participation", new SortCommand(participation));
+    public void parse_validName_returnsSortCommand() {
+        SortDescriptor descriptor = new SortDescriptor();
+        descriptor.setSortByName();
+        SortCommand expectedCommand = new SortCommand(descriptor);
+        assertParseSuccess(parser, " /by name", expectedCommand);
     }
 
     @Test
-    public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "", "Missing sort field.\n" + SortCommand.MESSAGE_USAGE);
-        assertParseFailure(parser, "name extra", "Only one sort field is allowed.\n" + SortCommand.MESSAGE_USAGE);
-        assertParseFailure(parser, "invalid", "Invalid sort field: 'invalid'.\n" + SortCommand.MESSAGE_USAGE);
+    public void parse_validGrade_returnsSortCommand() {
+        SortDescriptor descriptor = new SortDescriptor();
+        descriptor.setSortByGrade();
+        SortCommand expectedCommand = new SortCommand(descriptor);
+        assertParseSuccess(parser, " /by grade", expectedCommand);
+    }
+
+    @Test
+    public void parse_validAttendance_returnsSortCommand() {
+        SortDescriptor descriptor = new SortDescriptor();
+        descriptor.setSortByAttendance();
+        SortCommand expectedCommand = new SortCommand(descriptor);
+        assertParseSuccess(parser, " /by attendance", expectedCommand);
+    }
+
+    @Test
+    public void parse_validParticipation_returnsSortCommand() {
+        SortDescriptor descriptor = new SortDescriptor();
+        descriptor.setSortByParticipation();
+        SortCommand expectedCommand = new SortCommand(descriptor);
+        assertParseSuccess(parser, " /by participation", expectedCommand);
+    }
+
+    @Test
+    public void parse_missingPrefix_throwsParseException() {
+        assertParseFailure(parser, " name", "Sort command must include the /by prefix.\n" + SortCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, " grade", "Sort command must include the /by prefix.\n" + SortCommand.MESSAGE_USAGE);
+    }
+
+    @Test
+    public void parse_missingFieldAfterPrefix_throwsParseException() {
+        assertParseFailure(parser, " /by", "Missing /by and sort field.\n" + SortCommand.MESSAGE_USAGE);
+    }
+
+    @Test
+    public void parse_invalidField_throwsParseException() {
+        assertParseFailure(parser, " /by pizza", "Invalid sort field: 'pizza'.\n" + SortCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, " /by 123", "Invalid sort field: '123'.\n" + SortCommand.MESSAGE_USAGE);
+    }
+
+    @Test
+    public void parse_multipleFields_throwsParseException() {
+        assertParseFailure(parser, " /by name grade", "Only one sort field is allowed.\n" + SortCommand.MESSAGE_USAGE);
     }
 }


### PR DESCRIPTION
Introduces the CLI syntax '/by' followed by the required sort field.

Updates SortCommandParser and SortCommandParser accordingly.