### PR TITLE
Fix case sensitivity in SortCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -132,7 +132,9 @@ public class SortCommand extends Command {
          */
         public Comparator<Person> getComparator() {
             if (sortByName) {
-                return Comparator.comparing(p -> p.getName() != null ? p.getName().toString() : "");
+                return Comparator.comparing((Person p) -> p.getName() != null ? p.getName().toString().toLowerCase()
+                        : "", String.CASE_INSENSITIVE_ORDER).thenComparing(
+                                p -> p.getName() != null ? p.getName().toString() : "");
             } else if (sortByGrade) {
                 return Comparator.comparingInt(p -> p.getGrade() != null ? p.getGrade().grade : Integer.MAX_VALUE);
             } else if (sortByAttendance) {


### PR DESCRIPTION
Fixes #315 

Sorting by name with SortCommand is case sensitive. i.e. it returns
"A", "Z", "a" in that order rather than "A", "a", "Z".

This may be illogical to users.

Let's make sorting by name case insensitive.

This way, names that are similar are grouped together regardless of
case sensitivity.