### PR TITLE
Fix file path bugs in FileCommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@
 | `clear`             | Deletes all students.                                 | `clear`                                                                                                 |
 | `exit`              | Exits the application.                               | `exit`                                                                                                  |
 | `file /save`        | Saves data to a specified file.                         | `file /save CS2103T-T10-3`                                                                               |
-| `file /load`        | Loads data from a specified file.                         | `file /load CS2103T-T10-3`                                                                               |
-| `file /list all`    | Lists all available save files.                         | `file /list all`                                                                                       |
+| `file /load`        | Loads data from a specified file. (Without specifying the file extension)                        | `file /load CS2103T-T10-3`                                                                               |
+| `file /list all`    | Lists all available save files. (Without displaying the file extension)                        | `file /list all`                                                                                       |
 | `resetRecords`      | Resets attendance and participation records.            | `resetRecords`                                                                                        |
 | `help`              | Shows help message.                                  | `help`                                                                                                  |
 
-For more detailed documentation on the usage of commands in BetterCallTA, refer to our [User Guide](https://ay2425s2-cs2103t-t10-3.github.io/tp/UserGuide.html). 
+For more detailed documentation on the usage of commands in BetterCallTA, refer to our [User Guide](https://ay2425s2-cs2103t-t10-3.github.io/tp/UserGuide.html).
 
 ## Student Data
 
@@ -75,5 +75,3 @@ Each student's information includes:
 | NUS  | National University of Singapore                                          |
 
 For the complete User Guide, refer to the original documentation.
-
-

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -441,7 +441,7 @@ Clears all entries from the application 📇.
 clear
 ```
 
-If there are no students in BetterCallTA, an error message will be shown. 
+If there are no students in BetterCallTA, an error message will be shown.
 
 <div style="background-color: #dc3545; padding: 10px; border: 1px solid #000; border-radius: 5px; color: #FFF">
     <b>Alert!</b><br><br>
@@ -533,7 +533,7 @@ list
 
 ---
 
-### Saving Contact Data: `file /save`
+### Saving Contact Data: `file /save FILENAME`
 
 BetterCallTA data is automatically saved to `addressbook.json` in `[JAR file location]/data/` by default unless the save file is modified with the `file /load` command.
 
@@ -552,13 +552,26 @@ file /save SAVE_FILE
 <div style="background-color: #dc3545; padding: 10px; border: 1px solid #000; border-radius: 5px; color: #FFF">
     <b>Alert!</b>
     <ul>
-      <li>If the save file contains illegal characters, such as <code>[, /, :, *,? ,\ , ", <, >, |, ], ..</code> , it will be stripped.</li>
+      <li>
+        You do NOT need to specify the <code>.json</code> file extension as it will automatically be added by our application. If you attempt to include the file extension type <code>SAVE_FILE</code>, such as <code>save.pdf</code>, it will be saved as <code>save.pdf.json</code>. This is NOT a bug as <code>.</code> is a valid character that can be used in the filename of the save file.
+      </li>
+      <li>
+        The following illegal characters are not allowed in <code>SAVE_FILE</code>. <code>[, /, :, *,? ,\ , ", <, >, |, ], ..</code>
+      <li>
+      <li>
+        Whitespaces will be stripped and replace with underscores (<code>_</code>).
       <li>
         If the resultant file name of your input becomes empty in an edge case, the save file will be <code>file_TIMESTAMP</code>, where <code>TIMESTAMP</code> captures the timestamp of which the save file is created.
       </li>
-      <li>If the save file contains whitespace characters, it will be replaced with an underscore (<code>_</code>).
-      <li>If <code>SAVE_FILE.json</code> already exists in the <code>data</code> directory, it will be overwritten.</li>
-      <li>It is recommended NOT to modify the saved <code>SAVE_FILE.json</code> directly as it may introduce unintended behaviour in the application.</li>
+      <li>
+        If the save file contains whitespace characters, it will be replaced with an underscore (<code>_</code>).
+      </li>
+      <li>
+        If <code>SAVE_FILE.json</code> already exists in the <code>data</code> directory, it will be overwritten.
+      </li>
+      <li>
+        It is recommended NOT to modify the saved <code>SAVE_FILE.json</code> directly as it may introduce unintended behaviour in the application.
+      </li>
     </ul>
 </div><br>
 
@@ -569,7 +582,7 @@ file /save SAVE_FILE
 
 ---
 
-### Loading Contact Data: `file /load`
+### Loading Contact Data: `file /load FILENAME`
 
 BetterCallTA data will load the most recent save file 💾 that was used in the application by default. Save files can be loaded with the `file /load` command.
 
@@ -604,7 +617,7 @@ file /load SAVE_FILE
 
 ### 📂 Listing Save Files: `file /list all`
 
-BetterCallTA stores all save files in `[JAR file location]/data/` 💾 and the `file /list all` command will list out all `.json` save files in that directory, as well as indicating the current save file that is being in use by the application as indicated by `(current save file)`.
+BetterCallTA stores all save files in `[JAR file location]/data/` and the `file /list all` command will list out all `.json` save files in that directory (without the file extension type), as well as indicating the current save file that is being in use by the application as indicated by `(current save file)`.
 
 
 **Format**
@@ -612,7 +625,7 @@ BetterCallTA stores all save files in `[JAR file location]/data/` 💾 and the `
 file /list all
 ```
 
-Lists out all the save files stored by the application.
+Lists out all the `.json` save file filenames (without the file extension type) stored by the application in the `/data/*` directory.
 
 **Examples**:
 - `file /list all`
@@ -634,7 +647,7 @@ clear
 <br> Fig 3.10 - Output of `file /list all`
 <br> * Actual output may be different depending on what files are in `[JAR file location]/data/`
 
-— 
+—
 
 ### Resetting All Attendance and Participation Records: `resetRecords`
 

--- a/src/main/java/seedu/address/logic/commands/FileCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FileCommand.java
@@ -38,9 +38,12 @@ public class FileCommand extends Command {
             %s FILE_PATH
             %s all
 
+            Note:
+            FILE_PATH is the name of the file to load or save, without the .json extension.
+
             Example:
-            file /load savefile1
-            file /save savefile2
+            file /load classA
+            file /save homeroomB
             file /list all
             """;
 

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -132,7 +132,9 @@ public class SortCommand extends Command {
          */
         public Comparator<Person> getComparator() {
             if (sortByName) {
-                return Comparator.comparing(p -> p.getName() != null ? p.getName().toString() : "");
+                return Comparator.comparing((Person p) -> p.getName() != null ? p.getName().toString().toLowerCase()
+                        : "", String.CASE_INSENSITIVE_ORDER).thenComparing(
+                                p -> p.getName() != null ? p.getName().toString() : "");
             } else if (sortByGrade) {
                 return Comparator.comparingInt(p -> p.getGrade() != null ? p.getGrade().grade : Integer.MAX_VALUE);
             } else if (sortByAttendance) {

--- a/src/test/java/seedu/address/logic/parser/FileCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FileCommandParserTest.java
@@ -15,8 +15,8 @@ public class FileCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsFileCommand() {
-        String args = " /load data.json";
-        FileCommand expectedFileCommand = new FileCommand(FileOperation.LOAD, "data.json");
+        String args = " /load data test";
+        FileCommand expectedFileCommand = new FileCommand(FileOperation.LOAD, "data_test");
         assertParseSuccess(parser, args, expectedFileCommand);
     }
 
@@ -53,30 +53,11 @@ public class FileCommandParserTest {
         assertParseFailure(parser, args, expected);
     }
 
-    @Test
-    public void parse_sanitizeFilePath_returnsFileCommand() {
-        String args = " /load ../data";
-        String args2 = " /save ../?*data";
-        String args3 = " /load aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-
-        FileCommand expectedFileCommand = new FileCommand(FileOperation.LOAD, "data");
-        FileCommand expectedFileCommand2 = new FileCommand(FileOperation.SAVE, "data");
-        FileCommand expectedFileCommand3 = new FileCommand(FileOperation.LOAD,
-                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-
-        assertParseSuccess(parser, args, expectedFileCommand);
-        assertParseSuccess(parser, args2, expectedFileCommand2);
-        assertParseSuccess(parser, args3, expectedFileCommand3);
+    @Test void parse_invalidFileName_throwsParseException() {
+        String args = " /save ../invalid.json";
+        assertParseFailure(
+                parser,
+                args,
+                "File operation failed: File name ../invalid.json contains illegal characters.");
     }
-
 }


### PR DESCRIPTION
Fixes #287 

Users can use "." and "/" in file path, which may lead to file
navigability problems.

We should prevent this so that users cannot abuse the program to modify
their file directory in unintended ways.

Let's restrict the file path to alphanumeric characters and certain
symbols.

This also prevents any other symbol from possibly leading to an
unintended outcome.